### PR TITLE
Feat/auction api detail/#36 - 상세페이지 아이템 정보 로컬에 저장

### DIFF
--- a/src/axios/mypage/bid.ts
+++ b/src/axios/mypage/bid.ts
@@ -1,0 +1,53 @@
+import axiosInstance from '../instance';
+
+// Bid 아이템의 인터페이스 정의
+interface IBid {
+  id: number;
+  bidPrice: number;
+  auctionId: number;
+  auctionTitle: string;
+  thumbnailImageUrl: string;
+  memberId: string;
+  createdAt: string;
+}
+
+// 페이지 관련 인터페이스 정의
+interface ISort {
+  empty: boolean;
+  unsorted: boolean;
+  sorted: boolean;
+}
+
+interface IPageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: ISort;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}
+
+// 전체 응답 구조의 인터페이스 정의
+interface IBidHistoryResponse {
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+  content: IBid[]; // Bid 항목 배열
+  number: number;
+  sort: ISort;
+  pageable: IPageable;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+export const fetchBidData = async (): Promise<IBidHistoryResponse> => {
+  try {
+    const response = await axiosInstance.get<IBidHistoryResponse>('/api/bids');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching auction details:', error);
+    throw error;
+  }
+};

--- a/src/axios/mypage/qnaAsk.ts
+++ b/src/axios/mypage/qnaAsk.ts
@@ -1,0 +1,67 @@
+import axiosInstance from '../instance';
+
+// Answer 항목의 인터페이스 정의
+interface IAnswer {
+  id: number;
+  auctionId: number;
+  auctionTitle: string;
+  title: string;
+  content: string;
+  writerId: string;
+  imageList: string[];
+  createdAt: string;
+}
+
+// QnA 항목의 인터페이스 정의
+interface IQnA {
+  id: number;
+  auctionId: number;
+  auctionTitle: string;
+  title: string;
+  content: string;
+  writerId: string;
+  answerList: IAnswer[];
+  createdAt: string;
+}
+
+// 정렬 관련 인터페이스 정의
+interface ISort {
+  empty: boolean;
+  unsorted: boolean;
+  sorted: boolean;
+}
+
+// 페이지 관련 인터페이스 정의
+interface IPageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: ISort;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}
+
+// 전체 응답 구조의 인터페이스 정의
+interface IQnAResponse {
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+  content: IQnA[]; // QnA 항목 배열
+  number: number;
+  sort: ISort;
+  pageable: IPageable;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+export const fetchQnAAskData = async (): Promise<IQnAResponse> => {
+  try {
+    const response = await axiosInstance.get<IQnAResponse>('api/asks');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching auction details:', error);
+    throw error;
+  }
+};

--- a/src/axios/mypage/recharge.ts
+++ b/src/axios/mypage/recharge.ts
@@ -18,6 +18,7 @@ export const fetchRechargeData = async (
       },
     });
 
+    console.log(response.data);
     return response.data;
   } catch (error) {
     console.error('Error fetching auction details:', error);

--- a/src/components/detail/AuctionDetails.tsx
+++ b/src/components/detail/AuctionDetails.tsx
@@ -89,6 +89,16 @@ const AuctionDetails = ({ auctionId }) => {
   const handleBidSubmit = (event: React.FormEvent) => {
     event.preventDefault();
 
+    if (data.seller.memberId === memberId) {
+      toast({
+        description: '본인의 경매는 입찰할 수 없습니다.',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
     const bidPrice = bidPriceRef.current?.value;
     console.log('입력된 입찰 금액:', bidPrice);
 
@@ -166,7 +176,7 @@ const AuctionDetails = ({ auctionId }) => {
             현재 입찰가
           </Text>
           <Text fontSize={{ base: 'md', sm: 'lg', md: 'xl' }} fontWeight="bold" pl="10px">
-            {data?.startPrice ? `${formatPrice(data.startPrice)}원` : '가격 정보 없음'}
+            {data?.currentPrice ? `${formatPrice(data.currentPrice)}원` : '가격 정보 없음'}
           </Text>
         </Flex>
         <Flex alignItems="end">

--- a/src/components/detail/AuctionDetails.tsx
+++ b/src/components/detail/AuctionDetails.tsx
@@ -193,6 +193,10 @@ const AuctionDetails = ({ auctionId }) => {
         <Text fontSize="lg" mb={2}>
           {data?.productName}
         </Text>
+        {/* 컬러값 */}
+        <Text fontSize="md" color="gray.600">
+          {data?.productColor}
+        </Text>
         <Text fontSize="md" color="gray.600">
           {data?.productDescription}
         </Text>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -13,7 +13,9 @@ export default function Layout() {
     location.pathname === '/mypage/myinfo' ||
     location.pathname === '/mypage/buy' ||
     location.pathname === '/mypage/sell' ||
-    location.pathname === '/mypage/charge';
+    location.pathname === '/mypage/charge' ||
+    location.pathname === '/mypage/answer' ||
+    location.pathname === '/mypage/ask';
 
   const hideFooter =
     location.pathname === '/mypage/myinfo' ||
@@ -23,7 +25,9 @@ export default function Layout() {
     location.pathname === '/rooms' ||
     location.pathname === '/payment' ||
     location.pathname === '/members/payment/approve' ||
-    location.pathname === '/members/payment/cancel';
+    location.pathname === '/members/payment/cancel' ||
+    location.pathname === '/mypage/answer' ||
+    location.pathname === '/mypage/ask';
 
   return (
     <>

--- a/src/components/mypage/myInfo/MyInfo.tsx
+++ b/src/components/mypage/myInfo/MyInfo.tsx
@@ -9,11 +9,8 @@ import {
   ListItem,
   UnorderedList,
   Text,
-  Table,
-  Tbody,
-  Tr,
-  Td,
 } from '@chakra-ui/react';
+import MyInfoTable from './MyInfoTable';
 // import Calendar from '../calendar/Calendar';
 
 export default function MyInfo() {
@@ -39,15 +36,17 @@ export default function MyInfo() {
           flex="1" // 남은 공간을 차지하도록 설정
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={8} flex="1">
-            <Flex direction="column" gap={2} w="100%">
+            <Flex direction="column" gap={2} w={{ base: '100%', md: '350px' }}>
               <Flex justifyContent="space-between">
                 <div>이메일</div>
                 <div>수정</div>
               </Flex>
-              <InputGroup>
-                <Input w="100%" />
-                <InputRightElement width="5rem">
-                  <Button fontSize="small">인증번호 받기</Button>
+              <InputGroup size="md">
+                <Input pr="5.5rem" type="text" placeholder="이메일을 입력해주세요" />
+                <InputRightElement width="4.5rem" mr="0.4rem">
+                  <Button h="1.75rem" size="sm" fontSize="xs">
+                    인증번호 받기
+                  </Button>
                 </InputRightElement>
               </InputGroup>
             </Flex>
@@ -60,125 +59,13 @@ export default function MyInfo() {
         </Flex>
       </Flex>
       <Flex direction="column" gap="2">
-        <Text>입찰 내역</Text>
+        <Text fontSize="lg" fontWeight="bold">
+          입찰 내역
+        </Text>
         {/* <Calendar /> */}
       </Flex>
-
       {/* 테이블 */}
-      <div className="overflow-y-scroll no-scrollbar h-full">
-        <Table variant="simple" width="full" sx={{ tableLayout: 'fixed' }}>
-          <Tbody>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>2012000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-            <Tr>
-              <Td>아이템이름</Td>
-              <Td>
-                <Box display="flex" justifyContent="end" gap="6">
-                  <Box className="block">2024-08-14</Box>
-                  <Box>20000P</Box>
-                </Box>
-              </Td>
-            </Tr>
-          </Tbody>
-        </Table>
-      </div>
+      <MyInfoTable />
     </Box>
   );
 }

--- a/src/components/mypage/myInfo/MyInfoTable.tsx
+++ b/src/components/mypage/myInfo/MyInfoTable.tsx
@@ -1,0 +1,80 @@
+import {
+  Card,
+  Flex,
+  Spinner,
+  Image,
+  Stack,
+  CardBody,
+  Heading,
+  Text,
+  Divider,
+  SimpleGrid,
+  Box,
+} from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchBidData } from '../../../axios/mypage/bid';
+import { formatPrice } from '../../../utils/formatPrice';
+
+export default function MyInfoTable() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['bidList'],
+    queryFn: fetchBidData,
+  });
+
+  console.log('bidList:', data);
+
+  if (isLoading) {
+    return (
+      <Flex justifyContent="center" alignItems="center" height="100%" width="100%">
+        <Spinner size="xl" />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return <div>Error loading data</div>;
+  }
+
+  return (
+    <Box
+      overflowY="scroll"
+      css={{
+        '&::-webkit-scrollbar': { display: 'none' }, // 크롬, 사파리에서 스크롤바 숨기기
+        '-ms-overflow-style': 'none', // IE, Edge에서 스크롤바 숨기기
+        'scrollbar-width': 'none', // 파이어폭스에서 스크롤바 숨기기
+      }}
+      h="full"
+      maxH={{ base: '72', sm: 'full' }}
+      p={2}
+      borderRadius="lg"
+      boxShadow="lg"
+    >
+      <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
+        {data.content.map(bidItem => (
+          <Card key={bidItem.id}>
+            <CardBody>
+              <Image
+                src={bidItem.thumbnailImageUrl}
+                alt="썸네일 이미지"
+                borderRadius="lg"
+                objectFit="cover" // 이미지 비율 유지
+                height={{ base: '200px', md: '250px' }} // 이미지 크기 조정
+                width="100%" // 카드에 맞춰 이미지 크기 조정
+              />
+              <Stack mt="6" spacing="3">
+                <Heading size="md" noOfLines={2}>
+                  {bidItem.auctionTitle}
+                </Heading>
+                <Divider />
+                <Text fontSize="sm">{bidItem.createdAt}</Text>
+                <Text color="blue.600" fontSize="xl" fontWeight="bold">
+                  {formatPrice(bidItem.bidPrice)}원
+                </Text>
+              </Stack>
+            </CardBody>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/src/components/mypage/order/OrderTable.tsx
+++ b/src/components/mypage/order/OrderTable.tsx
@@ -5,6 +5,7 @@ import {
   AccordionItem,
   AccordionPanel,
   Box,
+  Image,
   Table,
   Tbody,
   Td,
@@ -16,12 +17,21 @@ import {
 
 import { useLocation } from 'react-router-dom';
 import { formatPrice } from '../../../utils/formatPrice';
+import { formatDate } from '../../../utils/dateFormat';
 
 export default function OrderTable({ posts }) {
   const location = useLocation();
   const isBuyPage = location.pathname === '/mypage/buy';
 
+  console.log('dataaa:', posts);
+
   const fontSize = useBreakpointValue({ base: 'xs', md: 'sm', lg: 'md' });
+
+  const receiveTypeMapping = {
+    CONTACT: '대면 거래',
+    DELIVERY: '택배',
+    ALL: '모두 가능',
+  };
 
   if (!posts || posts.length === 0) {
     return <div>{isBuyPage ? '구매' : '판매'} 목록이 없습니다.</div>;
@@ -114,7 +124,7 @@ export default function OrderTable({ posts }) {
                         paddingY={{ base: '6px', md: '20px' }}
                         fontSize={fontSize}
                       >
-                        {item.saleDate}
+                        {item.saleDate.slice(0, 10)}
                       </Box>
                       <div className="absolute right-3">
                         <AccordionIcon />
@@ -130,7 +140,7 @@ export default function OrderTable({ posts }) {
                       >
                         <Box className="flex flex-col gap-6">
                           <p className="flex flex-col gap-1">
-                            <strong>수령 방법</strong> {item.receiveType}
+                            <strong>수령 방법</strong> {receiveTypeMapping[item.receiveType]}
                           </p>
                           <p className="flex flex-col gap-1">
                             <strong>상품명</strong> {item.productName}
@@ -141,13 +151,13 @@ export default function OrderTable({ posts }) {
                         </Box>
                         <Box className="flex flex-col gap-6">
                           <p className="flex flex-col gap-1">
-                            <strong>상태</strong> {item.productStatus}
+                            <strong>상태</strong> {item.productStatus}/5
                           </p>
                           <p className="flex flex-col gap-1">
-                            <strong>결제 금액</strong> {formatPrice(item.salePrice)}
+                            <strong>결제 금액</strong> {formatPrice(item.salePrice)}원
                           </p>
                           <p className="flex flex-col gap-1">
-                            <strong>입찰 시작가</strong> {item.startPrice}
+                            <strong>입찰 시작가</strong> {formatPrice(item.startPrice)}원
                           </p>
                         </Box>
                         <Box className="flex flex-col gap-6">
@@ -156,13 +166,21 @@ export default function OrderTable({ posts }) {
                             {item.sellerEmail}
                           </p>
                           <p className="flex flex-col gap-1">
-                            <strong>{isBuyPage ? '구매' : '판매'} 날짜</strong> {item.saleDate}
+                            <strong>{isBuyPage ? '구매' : '판매'} 날짜</strong>{' '}
+                            {formatDate(item.saleDate)}
                           </p>
                           <p className="flex flex-col gap-1">
-                            <strong>즉시 구매가</strong> {item.instantPrice}
+                            <strong>즉시 구매가</strong> {formatPrice(item.instantPrice)}원
                           </p>
                         </Box>
-                        <Box className="bg-stone-400"></Box>
+                        <Box className="bg-stone-400" width="100%" height="100%">
+                          <Image
+                            objectFit="cover"
+                            src={item.thumbnailUrl}
+                            width="100%"
+                            height="100%"
+                          />
+                        </Box>
                       </Box>
                     </AccordionPanel>
                   </AccordionItem>

--- a/src/components/mypage/order/QnAAnswerList.tsx
+++ b/src/components/mypage/order/QnAAnswerList.tsx
@@ -1,0 +1,3 @@
+export default function QnAAnswerList() {
+  return <div>QnAAnswerList</div>;
+}

--- a/src/components/mypage/order/QnAAskList.tsx
+++ b/src/components/mypage/order/QnAAskList.tsx
@@ -1,0 +1,53 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Flex,
+  Spinner,
+} from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchQnAAskData } from '../../../axios/mypage/qnaAsk';
+
+export default function QnAAskList() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['asks'],
+    queryFn: fetchQnAAskData,
+  });
+
+  console.log('asks:', data);
+
+  if (isLoading) {
+    return (
+      <Flex justifyContent="center" alignItems="center" height="100%" width="100%">
+        <Spinner size="xl" />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return <div>Error loading data</div>;
+  }
+
+  return (
+    <Accordion allowToggle>
+      <AccordionItem>
+        <h2>
+          <AccordionButton>
+            <Box as="span" flex="1" textAlign="left">
+              Section 1 title
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={4}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/src/components/mypage/order/RechargeHistory.tsx
+++ b/src/components/mypage/order/RechargeHistory.tsx
@@ -32,6 +32,8 @@ export default function RechargeHistory() {
     placeholderData: keepPreviousData,
   });
 
+  console.log('dataa:', data);
+
   const handlePageChange = (page: number) => {
     setParams(prev => ({ ...prev, currentPage: page }));
   };

--- a/src/components/mypage/order/RechargeTable.tsx
+++ b/src/components/mypage/order/RechargeTable.tsx
@@ -6,8 +6,10 @@ export default function RechargeTable({ posts }) {
   const tdPadding = useBreakpointValue({ base: '8px', md: '12px', lg: '16px' }); // 반응형 패딩 설정
 
   if (!posts || posts.length === 0) {
-    return <div>구매 목록이 없습니다.</div>;
+    return <div>거래 내역이 없습니다.</div>;
   }
+
+  console.log(posts);
 
   return (
     <div className="overflow-y-scroll no-scrollbar h-full max-sm:h-72">
@@ -20,12 +22,20 @@ export default function RechargeTable({ posts }) {
                 fontWeight={'bold'}
                 textAlign={'center'}
                 className={`${
-                  item.pointType === 'USE' ? 'bg-white text-black' : 'bg-black text-white'
-                }`}
+                  item.pointType === 'USE'
+                    ? 'bg-red-500 text-white'
+                    : item.pointType === 'CHARGE'
+                      ? 'bg-green-500 text-white'
+                      : 'bg-blue-500 text-white'
+                }`} // pointType에 따른 배경색 및 텍스트 색상 변경
                 fontSize={fontSize} // 반응형 폰트 사이즈 적용
                 padding={tdPadding} // 반응형 패딩 적용
               >
-                {item.pointType === 'USE' ? '사용' : '충전'}
+                {item.pointType === 'USE'
+                  ? '사용'
+                  : item.pointType === 'CHARGE'
+                    ? '충전'
+                    : '판매 수익'}
               </Td>
               <Td padding={tdPadding}>
                 <Box display="flex" justifyContent="space-between" fontSize={fontSize}>

--- a/src/pages/AuctionDetail.tsx
+++ b/src/pages/AuctionDetail.tsx
@@ -7,14 +7,48 @@ import QnASection from '../components/detail/QnASection';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchAuctionDetailData } from '../axios/auctionDetail/auctionDetail';
+import { useEffect } from 'react';
 
 const AuctionDetail = () => {
   const { id: auctionId } = useParams();
+  const memberId = localStorage.getItem('memberId');
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['detail', auctionId],
     queryFn: () => fetchAuctionDetailData(auctionId),
   });
+
+  console.log('데이터', data);
+
+  // 로컬에 내가본 경매 정보 저장
+  useEffect(() => {
+    if (data) {
+      // 필요한 데이터 추출
+      const auctionState = data.auctionState;
+      const thumbnailImage = data.imageList.find(image => image.imageType === 'THUMBNAIL');
+      const title = data.productName;
+      const id = data.id;
+
+      // 로컬 스토리지에 저장
+      const recentAuction = {
+        auctionState,
+        thumbnailUrl: thumbnailImage.imageUrl, // 해당 이미지의 URL을 저장
+        title,
+        id,
+      };
+
+      // 기존 저장된 경매 리스트 불러오기
+      const recentAuctions = JSON.parse(localStorage.getItem(memberId)) || [];
+
+      // 새로 본 경매를 리스트에 추가
+      const updatedRecentAuctions = [
+        recentAuction,
+        ...recentAuctions.filter(item => item.id !== id),
+      ].slice(0, 10); // 최대 10개까지만 저장
+
+      localStorage.setItem(memberId, JSON.stringify(updatedRecentAuctions));
+    }
+  }, [data, memberId]);
 
   if (isLoading) {
     <div>Data Loading...</div>;

--- a/src/pages/AuctionMyPage.tsx
+++ b/src/pages/AuctionMyPage.tsx
@@ -24,6 +24,8 @@ export default function AuctionMyPage() {
     { icon: <FaShoppingCart />, label: '구매 내역', path: '/mypage/buy' },
     { icon: <RiDiscountPercentFill />, label: '판매 내역', path: '/mypage/sell' },
     { icon: <SiLightning />, label: '충전 내역', path: '/mypage/charge' },
+    { icon: <SiLightning />, label: '질문 내역', path: '/mypage/ask' },
+    { icon: <SiLightning />, label: '답변 내역', path: '/mypage/answer' },
   ];
 
   const handleItemClick = (path: string) => {

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -10,6 +10,8 @@ import PurchaseHistory from '../components/mypage/order/PurchaseHistory';
 import SellHistory from '../components/mypage/order/SellHistory';
 import RechargeHistory from '../components/mypage/order/RechargeHistory';
 import Payment from '../pages/Payment';
+import QnAAnswerList from '../components/mypage/order/QnAAnswerList';
+import QnAAskList from '../components/mypage/order/QnAAskList';
 
 export const router = createBrowserRouter([
   {
@@ -52,6 +54,14 @@ export const router = createBrowserRouter([
           {
             path: 'charge',
             element: <RechargeHistory />,
+          },
+          {
+            path: 'answer',
+            element: <QnAAnswerList />,
+          },
+          {
+            path: 'ask',
+            element: <QnAAskList />,
           },
         ],
       },


### PR DESCRIPTION
## 📍 AS-IS
- AuctionDetail 페이지에 진입 시, 사용자가 최근 본 경매 정보가 로컬 스토리지에 저장되지 않음.
- “최근 본 경매” 기능을 구현할 수 있는 데이터가 페이지 로드 시 따로 저장되지 않음.

## 📍 TO-BE
- AuctionDetail 페이지에 진입할 때, 경매 상태(auctionState), 썸네일 이미지(thumbnailUrl), 제목(title), 경매 ID(id)가 
   로컬 스토리지에 저장됨.
- 로컬 스토리지에 최대 10개의 최근 본 경매 정보가 저장되며, 중복된 항목은 제거됨.